### PR TITLE
Update home-automation.yaml

### DIFF
--- a/color-kit-grande/esphome/home-automation.yaml
+++ b/color-kit-grande/esphome/home-automation.yaml
@@ -10,6 +10,11 @@ esp32:
 # Enable logging
 logger:
 
+# ILI9xxx updated in ESPHome 2025.02 require activation of the PSRAM. Throws allocation error if not and goes into safe mode. https://github.com/esphome/esphome/pull/8084
+psram:
+  mode: octal
+  speed: 80MHz
+
 # Enable Home Assistant API
 api:
   encryption:


### PR DESCRIPTION
ESPHome 2025.2.0 implements breaking change in ili9xxx which require PSRAM to be explicitly enabled. Getting allocation error without. https://github.com/esphome/esphome/pull/8084